### PR TITLE
refactor(pip-compile): add working-directory input

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ dependencies, specified in either `pyproject.toml`, `setup.cfg`, `setup.py`, or
 **Inputs**:
 
 - `path` (`string`): A file or location of the requirement file(s).
+- `working-directory` (`string`): Useful when the path input is a file inside a
+  directory.
 - `python-version` (`string`): Python version to use for installing `pip-tools`.
   You may use MAJOR.MINOR or exact version. Defaults to `'3.12'`. Optional.
 

--- a/pip-compile/action.yaml
+++ b/pip-compile/action.yaml
@@ -29,9 +29,18 @@ runs:
           --tag coatl-pip-compile:${{ inputs.python-version }}
 
     - shell: bash
+      id: check-working-directory
+      run: |
+        if [ "${{ inputs.working-directory }}" = '.' ]; then
+          echo "cwd=$(pwd)" >> "$GITHUB_OUTPUT"
+        else
+          echo "cwd=${{ inputs.working-directory }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - shell: bash
       run: |
         docker run --rm \
           --env "INPUT_PATH=${{ inputs.path }}" \
-          --env "INPUT_WORKING_DIRECTORY=${{ inputs.working-directory }}" \
+          --env "INPUT_WORKING_DIRECTORY=${{ steps.check-working-directory.outputs.cwd }}" \
           --volume ${{ github.workspace }}://github/workspace \
           coatl-pip-compile:${{ inputs.python-version }}

--- a/pip-compile/action.yaml
+++ b/pip-compile/action.yaml
@@ -7,6 +7,11 @@ inputs:
     description: >-
       A file or location of the requirement file(s).
     required: true
+  working-directory:
+    description: >-
+      Useful when the path input is a file inside a directory.
+    required: false
+    default: '.'
   python-version:
     description: >-
       Python version to use for installing pip-tools.
@@ -27,5 +32,6 @@ runs:
       run: |
         docker run --rm \
           --env "INPUT_PATH=${{ inputs.path }}" \
+          --env "INPUT_WORKING_DIRECTORY=${{ inputs.working-directory }}" \
           --volume ${{ github.workspace }}://github/workspace \
           coatl-pip-compile:${{ inputs.python-version }}

--- a/pip-compile/entrypoint.sh
+++ b/pip-compile/entrypoint.sh
@@ -10,6 +10,12 @@ function process_file() {
   eval "$command"
 }
 
+if [ -d "{INPUT_WORKING_DIRECTORY}" ]; then
+  cd "${INPUT_WORKING_DIRECTORY}" || exit
+else
+  exit 1
+fi
+
 if [ -d "${INPUT_PATH}" ]; then
   cd "${INPUT_PATH}" || exit
   for file in *.txt; do


### PR DESCRIPTION
Useful when the path input is a file inside a directory
