### PR TITLE
refactor(uv-pip-compile): add single quotes before passing python-version

### DIFF
--- a/uv-pip-compile/action.yaml
+++ b/uv-pip-compile/action.yaml
@@ -27,7 +27,7 @@ runs:
     - uses: astral-sh/setup-uv@v6
       with:
         enable-cache: 'false'
-        python-version: ${{ inputs.python-version }}
+        python-version: '${{ inputs.python-version }}'
         version: ${{ inputs.uv-version }}
 
     - name: Create Pull Request


### PR DESCRIPTION
would not want to convert 3.10 to 3.1 inadvertently
