### PR TITLE
refactor(pip-compile): add ability to use config file

### DIFF
--- a/pip-compile/Dockerfile
+++ b/pip-compile/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     python -m pip install \
         pip-tools \
         # https://github.com/jazzband/pip-tools/issues/2176
-        'pip==25.0.1'
+        'pip<25.1'
 
 COPY action.sh /action.sh
 RUN chmod +x /action.sh

--- a/pip-compile/Dockerfile
+++ b/pip-compile/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     python -m pip install \
         pip-tools \
         # https://github.com/jazzband/pip-tools/issues/2176
-        'pip<25.1'
+        'pip==25.0.1'
 
 COPY action.sh /action.sh
 RUN chmod +x /action.sh

--- a/pip-compile/action.sh
+++ b/pip-compile/action.sh
@@ -6,8 +6,26 @@ source /etc/profile  # Makes python and other executables findable
 
 function process_file() {
   local file="$1"
-  command=$(grep -m 1 "#    pip-compile" "$file" | sed 's/#    pip-compile/pip-compile --upgrade/')
-  eval "$command"
+  local config_file="$INPUT_CONFIG_FILE"
+  local use_config="$INPUT_USE_CONFIG"
+
+  if [ "$use_config" == "yes" ]; then
+    local config_file="${file%.txt}.in"
+    if [ -f "$config_file" ]; then
+      echo "Using config file: $config_file"
+      pip-compile --upgrade "$file" --config-file "$config_file"
+    else
+      echo "Config file not found: $config_file"
+      exit 1
+    fi
+  else
+    command=$(grep -m 1 "#    pip-compile" "$file" | sed 's/#    pip-compile/pip-compile --upgrade/')
+    if [ -n "$command" ]; then
+      eval "$command"
+    else
+      pip-compile "$file"
+    fi
+  fi
 }
 
 if [ -d "${INPUT_PATH}" ]; then

--- a/pip-compile/action.yaml
+++ b/pip-compile/action.yaml
@@ -12,6 +12,16 @@ inputs:
       Python version to use for installing pip-tools.
     required: false
     default: '3.13'
+  use-config:
+    description: >-
+      Whether to read configuration from TOML file.
+    required: false
+    default: 'no'
+  config-file:
+    description: >-
+      The location of the configuration file for pip-compile.
+    required: false
+    default: '.pip-tools.toml'
 
 runs:
   using: composite
@@ -27,5 +37,7 @@ runs:
       run: |
         docker run --rm \
           --env "INPUT_PATH=${{ inputs.path }}" \
+          --env "INPUT_USE_CONFIG=${{ inputs.use-config }}" \
+          --env "INPUT_CONFIG_FILE=${{ inputs.config-file }}" \
           --volume ${{ github.workspace }}://github/workspace \
           coatl-pip-compile:${{ inputs.python-version }}


### PR DESCRIPTION
pip-compile can use a configuration file (.pip-tools.toml,
pyproject.toml or another TOML file).
