### PR TITLE
refactor(uv-pip-compile): add path to uv before running action.sh

### DIFF
--- a/uv-pip-compile-upgrade/action.yaml
+++ b/uv-pip-compile-upgrade/action.yaml
@@ -29,7 +29,8 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
 
-    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+    - uses: astral-sh/setup-uv@v8.1.0
+      id: setup_uv
       with:
         enable-cache: 'false'
         python-version: '${{ inputs.python-version }}'
@@ -45,7 +46,11 @@ runs:
     - name: Create Pull Request
       shell: bash
       env:
+        UV_BIN_PATH: ${{ steps.setup_uv.outputs.uv-path }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
+        if [ -n "${UV_BIN_PATH:-}" ]; then
+          export PATH="$(dirname "${UV_BIN_PATH}"):$PATH"
+        fi
         action.sh


### PR DESCRIPTION
workflows are failing with the following error:
uv: command not found
