### PR TITLE
fix(pr-create): revert to previous functioning state

### DIFF
--- a/pr-create/action.sh
+++ b/pr-create/action.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-IFS=$'\n\t'
 
 # Parse INPUT_ADDITIONAL_ARGS into an array so multiple args are preserved
 ADDITIONAL_ARGS_ARR=()


### PR DESCRIPTION
remove IFS=$'\n\t' introduced in recent versions
